### PR TITLE
Support matching lines that contain comments

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -10,16 +10,16 @@
   +   '<button id="js_lua_beautify">Beautify</button>'
   + '</div>'
   ;
-  
+
   // This program reads a lua source code and formats it
   // It's based on <http://migre.me/mEbec>
-  
+
       // Spaces or tabs or even other strings
   var indentation = "  "
     , js_lua_code = document.querySelector("#js_lua_code")
     , js_lua_beautify = document.querySelector("#js_lua_beautify")
   ;
-  
+
   // Checks if a string (self) starts with another one (phrase)
   // @param self the original string
   // @param phrase the other string that is supposedly at the beginning of the string
@@ -27,7 +27,7 @@
   function startsWith(self, phrase) {
     return phrase.length && self.length && !self.indexOf(phrase);
   }
-  
+
   // Checks if a string (self) starts with another one (phrase)
   // @param self the original string
   // @param phrase the other string that is supposedly at the end of the string
@@ -36,14 +36,14 @@
     var last_index_of = self.lastIndexOf(phrase);
     return phrase.length && self.length && ~last_index_of && (last_index_of === self.length - phrase.length);
   }
-  
+
   // Removes whitespace from both ends of the string
   // @param self the string
   // @return string
   function trim(self) {
     return self.replace(/^\s+|\s+$/g, "");
   }
-  
+
   // Repeats a string n times
   // @param self the string
   // @param times number
@@ -55,7 +55,21 @@
     while(--times) self += copy;
     return self;
   }
-  
+
+  function stripComments(string) {
+    // walk through the line finding the first occurrence of -- not in a string
+    var sq = 0, dq = 0;
+    for (var i = 0; i < string.length; i++) {
+      if (string[i] == '\'') sq++;
+      if (string[i] == '\"') dq++;
+      if (string[i] == '-' && string[i + 1] == '-' &&
+          sq % 2 == 0 && dq % 2 == 0) {
+        return string.substr(0, i);
+      }
+    }
+    return string;
+  }
+
   // Beautify the Lua code
   // @param string the code to beautify
   // @param indentation the base string used for indentation
@@ -64,12 +78,12 @@
     var current_indentation = 0
       , next_indentation = 0
     ;
-    
-    return string.split(/\r?\n/).map(function(line) {
-      line = trim(line);
-      
+
+    return string.split(/\r?\n/).map(function(raw_line) {
+      line = trim(stripComments(raw_line));
+
       current_indentation = next_indentation;
-      
+
       // Entering in a block
       if(
         startsWith(line, "local function") ||
@@ -80,32 +94,33 @@
         endsWith(line, "do") ||
         endsWith(line, "{")
       ) next_indentation = current_indentation + 1;
-      
+
       // Leaving a block
       if(line === "end" || startsWith(line, "}") || startsWith(line, "until")) {
         current_indentation--;
         next_indentation = current_indentation;
       }
-      
+
       // Entering in a block but this line must be pushed back
       if(startsWith(line, "else") || startsWith(line, "elseif")) {
         current_indentation--;
         next_indentation = current_indentation + 1;
       }
-      
-      return !line ? "" : repeat(indentation, current_indentation) + line;
+
+      var out_line = trim(raw_line);
+      return !out_line ? "" : repeat(indentation, current_indentation) + out_line;
     }).join("\n");
   }
-  
+
   js_lua_code.addEventListener("keydown", function(e) {
     // If Ctrl + Enter then beautify
     if(e.ctrlKey && e.keyCode === 13) js_lua_beautify.click();
   });
-  
+
   js_lua_beautify.addEventListener("click", function() {
     js_lua_code.value = luaBeautifier(js_lua_code.value, indentation);
     js_lua_code.focus();
   });
-  
+
   js_lua_code.focus();
 }()


### PR DESCRIPTION
The formatter currently currently fails to match certain keywords if the
line contains a comment at the end. Trim comments out using a simple
detection algorithm (first "--" not preceded by an odd number of quote
characters) and use *that* for matching, then re-trim the raw line and
insert appropriate indentation.

Test data:
```
-------------------------------------------------
--         Put your Lua functions here.        --
--                                             --
-- Note that you can also use external Scripts --
-------------------------------------------------
Vstore = Vstore or {}
local PATH_SEP = string.char(getMudletHomeDir():byte()) == "/" and "/" or "\\"
local file =  getMudletHomeDir()..PATH_SEP.."Saved_Info"
--echo(file)

function onEventHandler( event, args )
--echo(event)

--echo(file)
if event == "sysDataSendRequest" then
OlastCommand = args
elseif event == "sysLoadEvent" then
echo("SYSTEM: sysExitEvent event has been raised, loading system variables ... ")
local start = Ostart()
LoadColor()
	if start == false
  then --get color
	table.load( file, Vstore )
	--display(Vstore)
	end
echo("OK\n")
else
echo("SYSTEM: sysExitEvent event has been raised, saving system variables ... ")
table.save(file, Vstore )
echo("OK\n")
end
end

function OvarSave(key,value)
Vstore[key]=value
--echo("Saved var:"..key.."="..value)
end--func

function OvarGet(key)
local value = Vstore[key]
--echo("Found var:"..key.."="..value)
return value
end--func
```

Ensure that `end` and `then` lines with comments are indented correctly,
and that comments are retained for the output.